### PR TITLE
chore(deps): patch vulnerable transitives

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
@@ -30,6 +31,7 @@
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="YamlDotNet" Version="17.1.0" />
     <PackageVersion Include="matkoch.spectre.console" Version="0.46.0" />
@@ -73,11 +75,13 @@
     <PackageVersion Update="Microsoft.Build.Framework" Version="17.14.28" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.14.28" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.14.28" />
+    <PackageVersion Update="System.Security.Cryptography.Xml" Version="9.0.15" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Update="Microsoft.Build" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Framework" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.11.48" />
+    <PackageVersion Update="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -57,6 +57,8 @@
   <ItemGroup>
     <PackageReference Include="Discord.Net.Webhook" Version="3.19.1" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.14.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageDownload Include="Codecov.Tool" Version="[1.13.0]" />
     <PackageDownload Include="docfx" Version="[2.78.5]" />
     <PackageDownload Include="GitVersion.Tool" Version="[6.6.0]" />
@@ -67,7 +69,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Frameworks" Version="6.14.3" />
     <ProjectReference Include="..\source\Nuke.Components.GitHub\Nuke.Components.GitHub.csproj" />
     <ProjectReference Include="..\source\Nuke.Components.Forgejo\Nuke.Components.Forgejo.csproj" />
     <ProjectReference Include="..\source\Nuke.Components.GitLab\Nuke.Components.GitLab.csproj" />


### PR DESCRIPTION
Fixes nuke-build/nuke#1591. (The Scriban update was done already.)

- Pins `System.Security.Cryptography.Xml` transitively to 10.0.6 / 9.0.15 / 8.0.3 per TFM, fixing **CVE-2026-33116** (GHSA-37gx-xxp4-5rgx) and **CVE-2026-26171** (GHSA-w3x6-4m5h-cxqf).
- Enables `CentralPackageTransitivePinningEnabled` so CPM lifts vulnerable transitives centrally via `Directory.Packages.props` (follows the existing TFM-conditional `<PackageVersion Update=…>` pattern used for `Microsoft.Build.*`).
- Adds a direct `<PackageReference>` for `System.Security.Cryptography.Xml` in `build/_build.csproj` because it opts out of CPM (`ManagePackageVersionsCentrally=false`).